### PR TITLE
Add pydemo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,39 @@ if(BUILD_DEMO)
     # copy essential config files next to our binary where OGRE autodiscovers them
     file(COPY ${OGRE_CONFIG_DIR}/plugins.cfg DESTINATION ${CMAKE_BINARY_DIR})
 endif()
+
+
+option(BUILD_DEMO2 "build demo2 application" TRUE)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/include/
+    ${PROJECT_SOURCE_DIR}/pydemo/
+    ${BULLET_INCLUDE_DIRS}
+    ${OGRE_INCLUDE_DIRS}
+)
+link_directories(${OGRE_LIBRARY_DIRS})
+
+add_library(btOgreLayer ${PROJECT_SOURCE_DIR}/BtOgre.cpp ${PROJECT_SOURCE_DIR}/pydemo/btOgreLayer.cpp)
+target_link_libraries(btOgreLayer ${BULLET_LIBRARIES} ${OGRE_LIBRARIES})
+
+INSTALL(TARGETS btOgreLayer
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+if(BUILD_DEMO2)
+    add_executable(btOgreLayerTest pydemo/demo2/main2.cpp)
+    target_link_libraries(btOgreLayerTest btOgreLayer)
+
+    configure_file(demo/data/resources.cfg.in ${CMAKE_BINARY_DIR}/resources.cfg @ONLY)
+
+    # copy essential config files next to our binary where OGRE autodiscovers them
+    file(COPY ${OGRE_CONFIG_DIR}/plugins.cfg DESTINATION ${CMAKE_BINARY_DIR})
+endif()
+
+# Python Bindings
+option(BUILD_USER_PYTHON "build user's python bindings" ON)
+if(BUILD_USER_PYTHON)
+    add_subdirectory(pydemo/python)
+endif()
+Message("Remember to set your own bullet sdk lib in your project, BulletConfig.cmake is not enough")

--- a/pydemo/btOgreLayer.cpp
+++ b/pydemo/btOgreLayer.cpp
@@ -1,0 +1,104 @@
+#include "BtOgrePG.h"
+#include "BtOgreGP.h"
+#include "BtOgreExtras.h"
+#include "btOgreLayer.h"
+#include <vector>
+
+using namespace Ogre;
+
+void btOgreLayer::basicConfig()
+{
+	//todo: config the gravity or broadphase in future
+}
+
+void btOgreLayer::initWorld()
+{
+	//Bullet initialisation.
+	mBroadphase = new btAxisSweep3(btVector3(-10000, -10000, -10000), btVector3(10000, 10000, 10000), 1024);
+	mCollisionConfig = new btDefaultCollisionConfiguration();
+	mDispatcher = new btCollisionDispatcher(mCollisionConfig);
+	mSolver = new btSequentialImpulseConstraintSolver();
+
+	phyWorld = new btDiscreteDynamicsWorld(mDispatcher, mBroadphase, mSolver, mCollisionConfig);
+	phyWorld->setGravity(btVector3(0, -9.8, 0));
+
+}
+
+void btOgreLayer::debugDrawer(Ogre::SceneNode *rootNode)
+{
+	// Debug drawing!
+	dbgdraw = new BtOgre::DebugDrawer(rootNode, phyWorld);
+	phyWorld->setDebugDrawer(dbgdraw);
+}
+
+void btOgreLayer::addRigidToWorld(Ogre::Entity *ent, Ogre::SceneNode *node)
+{
+
+	//todo: add shape and body into list in future
+	btCollisionShape *tShape;
+	BtOgre::StaticMeshToShapeConverter converter(ent);
+	tShape = converter.createSphere();
+	mShaps.push_back(tShape);
+	//Calculate inertia.
+	btScalar mass = 5;
+	btVector3 inertia;
+	tShape->calculateLocalInertia(mass, inertia);
+
+	//Create BtOgre MotionState (connects Ogre and Bullet).
+	BtOgre::RigidBodyState *tState = new BtOgre::RigidBodyState(node);
+	//Create the Body.
+	btRigidBody *tBody;
+	tBody = new btRigidBody(mass, tState, tShape, inertia);
+	mRigidbodys.push_back(tBody);
+	phyWorld->addRigidBody(tBody);
+
+}
+
+void btOgreLayer::addGroundToWorld(Ogre::Entity *ent)
+{
+	//Create the ground shape.
+	BtOgre::StaticMeshToShapeConverter converter2(ent);
+	mGroundShape = converter2.createTrimesh();
+
+	//Create MotionState (no need for BtOgre here, you can use it if you want to though).
+	btDefaultMotionState* groundState = new btDefaultMotionState(
+		btTransform(btQuaternion(0, 0, 0, 1), btVector3(0, 0, 0)));
+
+	//Create the Body.
+	btRigidBody *mGroundBody;
+	mGroundBody = new btRigidBody(0, groundState, mGroundShape, btVector3(0, 0, 0));
+	phyWorld->addRigidBody(mGroundBody);
+	mRigidbodys.push_back(mGroundBody);
+}
+void btOgreLayer::step(const FrameEvent &evt)
+{
+	phyWorld->stepSimulation(evt.timeSinceLastFrame, 10);
+	phyWorld->debugDrawWorld();
+	//Shows debug if F3 key down.
+	dbgdraw->step();
+}
+
+void btOgreLayer::destoryWorld()
+{
+	//Free rigid bodies
+	vector<btCollisionShape *>::iterator itShaps;
+	vector<btRigidBody *>::iterator itRigidbodys;
+	for (itRigidbodys = mRigidbodys.begin();itRigidbodys != mRigidbodys.end();itRigidbodys++) {
+		phyWorld->removeRigidBody(*itRigidbodys);
+		delete (*itRigidbodys)->getMotionState();
+		delete (*itRigidbodys);
+	}
+	for (itShaps = mShaps.begin();itShaps != mShaps.end();itShaps++)
+		delete (*itShaps);
+	delete mGroundShape->getMeshInterface();
+	delete mGroundShape;
+
+	//Free Bullet stuff.
+	delete dbgdraw;
+	delete phyWorld;
+	delete mSolver;
+	delete mDispatcher;
+	delete mCollisionConfig;
+	delete mBroadphase;
+
+}

--- a/pydemo/btOgreLayer.h
+++ b/pydemo/btOgreLayer.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <OgreEntity.h>
+#include <OgreSceneNode.h>
+#include "BtOgrePG.h"
+#include "BtOgreGP.h"
+#include "BtOgreExtras.h"
+#include <vector>
+
+namespace Ogre
+{
+	class btOgreLayer
+	{
+	public:
+		btDynamicsWorld *phyWorld;
+		BtOgre::DebugDrawer *dbgdraw=NULL;
+		btAxisSweep3 *mBroadphase;
+		btDefaultCollisionConfiguration *mCollisionConfig;
+		btCollisionDispatcher *mDispatcher;
+		btSequentialImpulseConstraintSolver *mSolver;
+		btBvhTriangleMeshShape *mGroundShape;
+		std::vector<btCollisionShape *>mShaps;
+		std::vector<btRigidBody *>mRigidbodys;
+
+		void basicConfig();
+		void initWorld();
+		void destoryWorld();
+		void debugDrawer(Ogre::SceneNode *);
+		void addRigidToWorld(Ogre::Entity *, Ogre::SceneNode *);
+		void addGroundToWorld(Ogre::Entity *);
+		void step(const FrameEvent &evt);
+	};
+}

--- a/pydemo/btOgreLayer.i
+++ b/pydemo/btOgreLayer.i
@@ -1,0 +1,40 @@
+%module(directors="1") pyBtOgreLayer
+%{
+#include "Ogre.h"
+#include "OgreEntity.h"
+#include "OgreSceneNode.h"
+#include "BtOgrePG.h"
+#include "BtOgreGP.h"
+#include "BtOgreExtras.h"
+#include "btOgreLayer.h"
+%}
+
+%include std_string.i
+%include exception.i
+%include stdint.i
+%include typemaps.i
+%import "Ogre.i"
+
+%include "btOgreLayer.h"
+%ignore Ogre::btOgreLayer::phyWorld;
+%ignore Ogre::btOgreLayer::dbgdraw;
+%ignore Ogre::btOgreLayer::mBroadphase;
+%ignore Ogre::btOgreLayer::mCollisionConfig;
+%ignore Ogre::btOgreLayer::mDispatcher;
+%ignore Ogre::btOgreLayer::mSolver;
+%ignore Ogre::btOgreLayer::mGroundShape;
+%ignore Ogre::btOgreLayer::mShaps;
+%ignore Ogre::btOgreLayer::mRigidbodys;
+
+
+
+
+#ifdef SWIGPYTHON
+%pythoncode
+%{
+    __version__ = "0.0"
+%}
+#endif
+
+
+

--- a/pydemo/python/CMakeLists.txt
+++ b/pydemo/python/CMakeLists.txt
@@ -1,0 +1,29 @@
+find_package(SWIG 3.0.8)
+find_package(PythonInterp)
+find_package(PythonLibs)
+
+if(NOT PYTHONLIBS_FOUND OR NOT SWIG_FOUND)
+    return()
+endif()
+
+include(${SWIG_USE_FILE})
+include_directories(${PYTHON_INCLUDE_PATH})
+
+set(CMAKE_SWIG_FLAGS -w401,314 -builtin -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS)
+
+set_source_files_properties(${CMAKE_SOURCE_DIR}/pydemo/btOgreLayer.i PROPERTIES CPLUSPLUS ON)
+
+if(MSVC)
+	add_definitions(/wd4101 /wd4102)
+else()
+    add_definitions(-Wno-cast-qual -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-label -Wno-unused-but-set-variable -Wno-missing-declarations)
+endif()
+
+swig_add_module(pyBtOgreLayer python ${CMAKE_SOURCE_DIR}/pydemo/btOgreLayer.i ${CMAKE_SOURCE_DIR}/pydemo/btOgreLayer.cpp)
+swig_link_libraries(pyBtOgreLayer btOgreLayer OgreMain ${PYTHON_LIBRARIES})
+set_target_properties(${SWIG_MODULE_pyBtOgreLayer_REAL_NAME} PROPERTIES DEBUG_POSTFIX "")
+
+# install
+set(PYTHON_SITE_PACKAGES lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages/)
+install(TARGETS ${SWIG_MODULE_pyBtOgreLayer_REAL_NAME} LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES})
+install(FILES ${PROJECT_BINARY_DIR}/pydemo/python/pyBtOgreLayer.py DESTINATION ${PYTHON_SITE_PACKAGES})

--- a/pydemo/python/btogre_sample.py
+++ b/pydemo/python/btogre_sample.py
@@ -1,0 +1,119 @@
+import Ogre
+from Ogre import RTShader, Overlay, Bites
+import pyBtOgreLayer
+
+
+class btOgreExample(Bites.ApplicationContext, Bites.InputListener):
+
+    def __init__(self):
+        Bites.ApplicationContext.__init__(self, "btOgreExample")
+        Bites.InputListener.__init__(self)
+    def loadResources(self):
+        self.enableShaderCache()
+
+        # load essential resources for trays/ loading bar
+        Ogre.ResourceGroupManager.getSingleton().initialiseResourceGroup("Essential")
+        self.createDummyScene()
+        self.trays = Bites.TrayManager("Interface", self.getRenderWindow())
+        self.addInputListener(self.trays)
+
+        # show loading progress
+        self.trays.showLoadingBar(1, 0)
+        ret = Bites.ApplicationContext.loadResources(self)
+
+        # clean up
+        self.trays.hideLoadingBar()
+        self.destroyDummyScene()
+        return ret
+    def keyPressed(self, evt):
+        if evt.keysym.sym == Bites.SDLK_ESCAPE:
+            self.getRoot().queueEndRendering()
+        return True
+
+    def frameStarted(self, evt):
+        Bites.ApplicationContext.frameStarted(self, evt)
+        self.bt.step(evt)
+        return True
+
+    def shutdown(self):
+        print("destoryWorld1")
+        self.bt.destoryWorld()
+        print("destoryWorld2")
+        del app.ctrls
+        del app.trays
+
+
+    def setup(self):
+        Bites.ApplicationContext.setup(self)
+        self.addInputListener(self)
+
+        root = self.getRoot()
+        scn_mgr = root.createSceneManager()
+
+        shadergen = RTShader.ShaderGenerator.getSingleton()
+        shadergen.addSceneManager(scn_mgr)  # must be done before we do anything with the scene
+
+        cam = scn_mgr.createCamera("myCam")
+        cam.setNearClipDistance(5)
+        cam.setAutoAspectRatio(True)
+        camnode = scn_mgr.getRootSceneNode().createChildSceneNode()
+        camnode.attachObject(cam)
+        self.camman = Bites.CameraMan(camnode)
+        self.camman.setStyle(Bites.CS_ORBIT)
+        self.camman.setYawPitchDist(Ogre.Radian(0), Ogre.Radian(0.3), 15)
+        self.addInputListener(self.camman)
+        # must keep a reference to ctrls so it does not get deleted
+        self.ctrls = Bites.AdvancedRenderControls(self.trays, cam)
+        self.addInputListener(self.ctrls)
+        vp = self.getRenderWindow().addViewport(cam)
+        vp.setBackgroundColour(Ogre.ColourValue(.3, .3, .3))
+        
+        
+        scn_mgr.setAmbientLight(Ogre.ColourValue(.1, .1, .1))
+
+        light = scn_mgr.createLight("MainLight")
+        lightnode = scn_mgr.getRootSceneNode().createChildSceneNode()
+        lightnode.setPosition(0, 10, 15)
+        lightnode.attachObject(light)
+
+
+
+
+
+
+
+   
+
+        ent = scn_mgr.createEntity("ninja.mesh")
+        btnode = scn_mgr.getRootSceneNode().createChildSceneNode('ninjabtnode',Ogre.Vector3(0,500,0),Ogre.Quaternion.IDENTITY)
+        node = btnode.createChildSceneNode('ninjaScenenode',Ogre.Vector3(0,-ent.getBoundingRadius()/2,0),Ogre.Quaternion.IDENTITY)      
+        node.attachObject(ent)
+        #print('dir pyBtOgreLayer=========>>')
+        #print(dir(pyBtOgreLayer))
+        #print(dir(pyBtOgreLayer.btOgreLayer()))
+
+
+
+        plane=Ogre.Plane(Ogre.Vector3(0,1,0),0)
+        Ogre.MeshManager.getSingleton().createPlane('ground','General',
+                                                    plane,100,100,10,10,
+                                                    True,
+                                                    1,1,1,
+                                                    Ogre.Vector3(0,0,1))
+        gdent=scn_mgr.createEntity('ground')
+        gdent.setMaterialName('Examples/Rockwall')
+        scn_mgr.getRootSceneNode().createChildSceneNode().attachObject(gdent)
+
+        
+        self.bt=bt=pyBtOgreLayer.btOgreLayer()
+        bt.initWorld()
+        bt.debugDrawer(scn_mgr.getRootSceneNode())
+
+        bt.addRigidToWorld(ent,btnode)
+        bt.addGroundToWorld(gdent)
+
+if __name__ == "__main__":
+    app = btOgreExample()
+    app.initApp()
+    app.getRoot().startRendering()
+    app.closeApp()


### PR DESCRIPTION
add 2 demos
DEMO2: using user's class(btOgreLayer) to use btogre
USER_PYTHON: using user's python module(which exported from user's class btOgreLayer) to drop the ninja on the ground

////////
This solution is not the best. It's more like a temporary or a compromised solution for users themselves.
I'm not sure is it worth to create a pull-request.
The best solution may be exporting all the interface of btogre directly and it involved bullet source files.
I don't know how to make that work, so I have to write a user's class(btOgreLayer in this case) and only export this user's class for python.
This method of the solution should also work on terrain or other c++ class which can not be exported as python interfaces theoretically.